### PR TITLE
add git-biodiff helper binary

### DIFF
--- a/src/bin/git-biodiff.rs
+++ b/src/bin/git-biodiff.rs
@@ -1,0 +1,12 @@
+use std::env;
+use std::process::exit;
+use std::process::Command;
+
+fn main() {
+    let status = Command::new("git")
+        .args(&["difftool", "--no-prompt", "--extcmd=biodiff"])
+        .args(env::args_os().skip(1))
+        .status()
+        .expect("Failed to run git");
+    exit(status.code().expect("Terminated by signal"));
+}


### PR DESCRIPTION
To use biodiff as diff tool in git, the user may either run
  `git difftool --no-prompt --extcmd=biodiff ...`
or, if a `git-biodiff` executable exists in the `PATH`, the user may run
  `git biodiff ...`
and the `git-biodiff` executable would run the first command. This handy
shortcut mechanism is also provided by `icdiff` when installing it.

Define an additional Rust binary to be installed with `cargo install`
which is easier than requiring the user to copy some bash script like
  `#!/bin/sh`
  `git difftool --no-prompt --extcmd=biodiff "$@"`
to their `PATH`.

Fixes https://github.com/8051Enthusiast/biodiff/issues/2