### PR TITLE
Add BIODIFF_CONFIG_DIR env variable to set custom settings directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Alternatively, you can also install this using `cargo` by doing `cargo install b
 
 You can also execute directly using code from this repository by executing `cargo run --release -- file_a file_b`.
 
+By default, settings are stored in a [platform-specific user directory](https://github.com/dirs-dev/dirs-rs#Features).
+To use a custom settings directory, set the `BIODIFF_CONFIG_DIR` environment variable to the desired directory path before running `biodiff`.
+If the directory doesn't exist, it will be automatically created.
+
 License
 -------
 This project is licensed under the MIT license.


### PR DESCRIPTION
With this environment variable, `biodiff` can be used as a fully portable application from e.g. a USB flash drive, by creating a launcher script that sets the environment variable.

Environment variable works better than a CLI option, because it automatically propagates through `git-biodiff`, `git` and other possible wrapper commands.